### PR TITLE
use env. var to select IK solver

### DIFF
--- a/config/kinematics_kdl.yaml
+++ b/config/kinematics_kdl.yaml
@@ -9,13 +9,3 @@ arm:
   kinematics_solver_timeout: 0.005
   kinematics_solver_attempts: 3
 
-#arm_torso:
-#  kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
-#  kinematics_solver_timeout: 0.005
-#  solve_type: Speed
-#  position_only_ik: false
-#arm:
-#  kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
-#  kinematics_solver_timeout: 0.005
-#  solve_type: Speed
-#  position_only_ik: false

--- a/config/kinematics_trac_ik.yaml
+++ b/config/kinematics_trac_ik.yaml
@@ -1,0 +1,10 @@
+arm_torso:
+  kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+  kinematics_solver_timeout: 0.005
+  solve_type: Speed
+  position_only_ik: false
+arm:
+  kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+  kinematics_solver_timeout: 0.005
+  solve_type: Speed
+  position_only_ik: false

--- a/launch/moveit_rviz.launch
+++ b/launch/moveit_rviz.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <launch>
 
   <arg name="debug" default="false" />
@@ -7,10 +8,13 @@
   <arg name="config" default="false" />
   <arg unless="$(arg config)" name="command_args" value="" />
   <arg     if="$(arg config)" name="command_args" value="-d $(find tiago_moveit_config)/launch/moveit.rviz" />
+
+  <!-- Selection of kinematics solver -->
+  <arg name="kinematics" value="$(optenv IK_SOLVER kdl)" />
   
   <node name="$(anon rviz)" launch-prefix="$(arg launch_prefix)" pkg="rviz" type="rviz" respawn="false"
 	args="$(arg command_args)" output="screen">
-    <rosparam command="load" file="$(find tiago_moveit_config)/config/kinematics.yaml"/>
+    <rosparam command="load" file="$(find tiago_moveit_config)/config/kinematics_$(arg kinematics).yaml"/>
   </node>
 
 </launch>

--- a/launch/planning_context.launch
+++ b/launch/planning_context.launch
@@ -3,6 +3,9 @@
   <!-- By default we do not overwrite the URDF. Change the following to true to change the default behavior -->
   <arg name="load_robot_description" default="false"/>
 
+  <!-- Selection of kinematics solver -->
+  <arg name="kinematics" value="$(optenv IK_SOLVER kdl)" />
+
   <!-- The name of the parameter under which the URDF is loaded -->
   <arg name="robot_description" default="robot_description"/>
 
@@ -22,7 +25,7 @@
 
   <!-- Load default settings for kinematics; these settings are overridden by settings in a node's namespace -->
   <group ns="$(arg robot_description)_kinematics">
-    <rosparam command="load" file="$(find tiago_moveit_config)/config/kinematics.yaml"/>
+    <rosparam command="load" file="$(find tiago_moveit_config)/config/kinematics_$(arg kinematics).yaml"/>
   </group>
   
 </launch>

--- a/launch/run_benchmark_ompl.launch
+++ b/launch/run_benchmark_ompl.launch
@@ -1,6 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <launch>
   <!-- Selector for tiago type -->
   <arg name="robot" default="titanium"/>
+
+  <!-- Selection of kinematics solver -->
+  <arg name="kinematics" value="$(optenv IK_SOLVER kdl)" />
 
   <!-- This argument must specify the list of .cfg files to process for benchmarking -->
   <arg name="cfg" />
@@ -18,7 +22,7 @@
 
   <!-- Start Benchmark Executable -->
   <node name="$(anon moveit_benchmark)" pkg="moveit_ros_benchmarks" type="moveit_run_benchmark" args="$(arg cfg) --benchmark-planners" respawn="false" output="screen">
-    <rosparam command="load" file="$(find tiago_moveit_config)/config/kinematics.yaml"/>
+    <rosparam command="load" file="$(find tiago_moveit_config)/config/kinematics_$(arg kinematics).yaml"/>
     <rosparam command="load" file="$(find tiago_moveit_config)/config/ompl_planning.yaml"/>
   </node>
 


### PR DESCRIPTION
With this merge the user can select the IK solver without modifying any file. Just like this:

roslaunch tiago_gazebo tiago_gazebo.launch public_sim:=true robot:=steel

KDL will be used as it is now the default IK solver.

In order to select TRAC-IK:

IK_SOLVER=trac_ik roslaunch tiago_gazebo tiago_gazebo.launch public_sim:=true robot:=steel